### PR TITLE
Add GitHub Actions for package publishing

### DIFF
--- a/.github/workflows/publish-rate.yml
+++ b/.github/workflows/publish-rate.yml
@@ -1,0 +1,25 @@
+name: Publish Rate Package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Publish Package
+        run: ./gradlew publish

--- a/.github/workflows/publish-stg-rate.yml
+++ b/.github/workflows/publish-stg-rate.yml
@@ -1,0 +1,25 @@
+name: Publish Stg-Rate Package
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Publish Package
+        run: ./gradlew publish

--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,34 @@ kotlin {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            name = 'stg'
+            url = uri('https://example.com/repository/stg')
+        }
+        maven {
+            name = 'rate'
+            url = uri('https://example.com/repository/rate')
+        }
+    }
+}
+
+task publishToMaster {
+    doLast {
+        publishing {
+            repositories {
+                maven {
+                    name = 'master'
+                    url = uri('https://example.com/repository/master')
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add GitHub Actions to publish Git packages for `rate` and `stg-rate`.

* **GitHub Actions Workflows**
  - Add `.github/workflows/publish-rate.yml` to automate publishing for the `rate` package on `master` branch.
  - Add `.github/workflows/publish-stg-rate.yml` to automate publishing for the `stg-rate` package on `develop` branch.

* **build.gradle**
  - Add publishing configuration for `stg` and `rate` repositories.
  - Add a new task `publishToMaster` to publish to the `master` branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Junnyjun/ratelimit/pull/1?shareId=abddc9e1-1194-41db-b685-e95ef5244369).