### PR TITLE
Fix git action errors and add manual trigger

### DIFF
--- a/.github/workflows/publish-rate.yml
+++ b/.github/workflows/publish-rate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish-stg-rate.yml
+++ b/.github/workflows/publish-stg-rate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,6 +18,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
+          distribution: 'adopt'
 
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
Add `distribution` input and manual trigger to GitHub Actions workflows.

* Add `distribution: 'adopt'` under the `with` section of the `actions/setup-java@v2` step in `.github/workflows/publish-stg-rate.yml`.
* Add `workflow_dispatch:` under the `on` section in `.github/workflows/publish-stg-rate.yml` to enable manual trigger.
* Add `workflow_dispatch:` under the `on` section in `.github/workflows/publish-rate.yml` to enable manual trigger.

